### PR TITLE
treewide: Refactor for clarity

### DIFF
--- a/build_binutils.sh
+++ b/build_binutils.sh
@@ -1,14 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
 # A Script to build GNU binutils
 set -e
 
+# Specify some variables.
 BUILDDIR=$(pwd)
 BINUTILS_DIR="$BUILDDIR/binutils-gdb"
 INSTALL_DIR="$BUILDDIR/install"
-BINTUILS_BUILD="$BUILDDIR/binutils-build"
+BINUTILS_BUILD="$BUILDDIR/binutils-build"
 PERSONAL=0
 
+# Notify build status to a Telegram chat.
 msg() {
+
 	if [[ $PERSONAL -eq 1 ]]; then
 		telegram-send "$1"
 	else
@@ -16,11 +20,16 @@ msg() {
 	fi
 }
 
+# The main build function that builds GNU binutils.
 build() {
-	rm -rf $BINTUILS_BUILD
-	mkdir -p $BINTUILS_BUILD
-	cd $BINTUILS_BUILD
-	if [[ $1 == "X86" ]]; then
+
+	if [ -d $BINUTILS_BUILD ]; then
+		rm -rf $BINUTILS_BUILD
+	fi
+	mkdir -p $BINUTILS_BUILD
+	cd $BINUTILS_BUILD
+	case $1 in
+	"X86")
 		"$BINUTILS_DIR"/configure \
 			CC="gcc" \
 			CXX="g++" \
@@ -48,7 +57,8 @@ build() {
 			--enable-ld=default \
 			--quiet \
 			--with-pkgversion="Neutron Binutils"
-	elif [[ $1 == "ARM64" ]]; then
+		;;
+	"ARM64")
 		"$BINUTILS_DIR"/configure \
 			CC="gcc" \
 			CXX="g++" \
@@ -76,7 +86,8 @@ build() {
 			--enable-ld=default \
 			--quiet \
 			--with-pkgversion="Neutron Binutils"
-	elif [[ $1 == "ARM" ]]; then
+		;;
+	"ARM")
 		"$BINUTILS_DIR"/configure \
 			CC="gcc" \
 			CXX="g++" \
@@ -104,10 +115,18 @@ build() {
 			--enable-ld=default \
 			--quiet \
 			--with-pkgversion="Neutron Binutils"
-	fi
+		;;
+	*)
+		echo "You have specified a wrong architecture type or one that we do not support! Do specify the correct one or feel free to make a PR with the relevant changes to add support to the architecture that you are trying to build this toolchain for."
+		exit 1
+		;;
+	esac
+
 	make -j$(($(nproc --all) + 2))
 	make install -j$(($(nproc --all) + 2))
 }
+
+# This is where the build starts.
 
 msg "Starting Binutils Build"
 

--- a/build_clang.sh
+++ b/build_clang.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
 # A custom Multi-Stage LLVM Toolchain builder.
 # PGO optimized clang for building Linux Kernels.
-#!/bin/bash
 set -e
 
+# Specify some variables.
 LINUX_VER="5.19"
 BINUTILS_VER="2_38"
 BUILDDIR=$(pwd)
@@ -42,7 +43,9 @@ if [[ $CLEAN_BUILD -eq 3 ]]; then
 	rm -rf $LLVM_BUILD
 fi
 
+# Where all relevant build-related repositories are cloned.
 llvm_clone() {
+
 	if ! git clone https://github.com/llvm/llvm-project.git; then
 		echo "llvm-project git clone: Failed" >&2
 		exit 1
@@ -50,6 +53,7 @@ llvm_clone() {
 }
 
 llvm_pull() {
+
 	if ! git pull https://github.com/llvm/llvm-project.git; then
 		echo "llvm-project git Pull: Failed" >&2
 		exit 1
@@ -57,6 +61,7 @@ llvm_pull() {
 }
 
 binutils_clone() {
+
 	if ! git clone https://sourceware.org/git/binutils-gdb.git -b binutils-$BINUTILS_VER-branch; then
 		echo "binutils git clone: Failed" >&2
 		exit 1
@@ -64,6 +69,7 @@ binutils_clone() {
 }
 
 binutils_pull() {
+
 	if ! git pull https://sourceware.org/git/binutils-gdb.git binutils-$BINUTILS_VER-branch; then
 		echo "binutils git Pull: Failed" >&2
 		exit 1
@@ -71,6 +77,7 @@ binutils_pull() {
 }
 
 get_linux_5_tarball() {
+
 	if [ -e linux-$1.tar.xz ]; then
 		echo "Existing linux-$1 tarball found, skipping download"
 		tar xf linux-$1.tar.xz
@@ -82,6 +89,7 @@ get_linux_5_tarball() {
 }
 
 build_temp_binutils() {
+
 	rm -rf $TEMP_BINTUILS_BUILD
 	mkdir -p $TEMP_BINTUILS_BUILD
 	if [ "$1" = "aarch64-linux-gnu" ]; then

--- a/post_build.sh
+++ b/post_build.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
 # Post Build script
 set -e
 
 PERSONAL=0
 
+# Notify build status to a Telegram chat.
 msg() {
 	if [[ $PERSONAL -eq 1 ]]; then
 		telegram-send "$1"

--- a/push.sh
+++ b/push.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
 # Script to push final built clang to my repo
 set -e
 
+# Specify some variables.
 CURRENT_DIR=$(pwd)
 BINUTILS_DIR="$CURRENT_DIR/binutils-gdb"
 LLVM_DIR="$CURRENT_DIR/llvm-project"
@@ -11,12 +13,14 @@ INSTALL_DIR="$CURRENT_DIR/install"
 release_date="$(date "+%B %-d, %Y")" # "Month day, year" format
 
 neutron_clone() {
+
 	if ! git clone git@gitlab.com:dakkshesh07/neutron-clang.git; then
 		exit 1
 	fi
 }
 
 neutron_pull() {
+
 	if ! git pull git@gitlab.com:dakkshesh07/neutron-clang.git; then
 		exit 1
 	fi


### PR DESCRIPTION
- Tidy up some bits.
- Use a case statement for binutils build.
- Fix typos in build_binutils.sh
- Use /usr/bin/env bash as shebang for all scripts.
- Disable SC2086 for shellcheck in all scripts.

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>